### PR TITLE
符号化方式をUTF-8 (BOMなし)、改行コードをLFに強制

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+end_of_line = lf
+charset = utf-8

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 [*]
 end_of_line = lf
 charset = utf-8
+guidelines = 120
 
 [*.cs]
 indent_size = 4

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,7 @@
 [*]
 end_of_line = lf
 charset = utf-8
+
+[*.cs]
+indent_size = 4
+indent_style = space

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf encoding=utf-8


### PR DESCRIPTION
Visual Studioはプロジェクトより上の .editorconfig を読み込むことができず、「テキストエディタの120行目にガイドラインを表示」は自分の好みで入れています。このコミットは削除してもらってもかまいません。